### PR TITLE
Remove outdated export info

### DIFF
--- a/src/collection-transfer.md
+++ b/src/collection-transfer.md
@@ -24,9 +24,6 @@ modifications (such as importing a shared deck you downloaded to your
 computer), and then export your collection and import it back into your
 mobile device.
 
-Exporting individual decks is not currently possible, but is planned
-for the future.
-
 ## Computer to iPhone/iPad
 
 ### Export the File


### PR DESCRIPTION
No longer accurate -- but single deck export doesn't fit with the "Collection Transfer" section. Corrected information will be added to `deck-list` in a separate PR.